### PR TITLE
feat!: GNOME 47, 48 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ slightly out of date compared to github.
 
 | GNOME Releases | ColorTint Releases                                                     | Extension Site version |
 |:---------------|:-----------------------------------------------------------------------|:-----------------------|
+| 49             | [latest](https://github.com/MattByName/color-tint/releases/latest)     | tbc                    |
 | 48             | [latest](https://github.com/MattByName/color-tint/releases/latest)     | tbc                    |
 | 47             | [latest](https://github.com/MattByName/color-tint/releases/latest)     | tbc                    |
 | 46             | [v3.0.0](https://github.com/MattByName/color-tint/releases/tag/v3.0.0) | tbc                    |

--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ slightly out of date compared to github.
 
 | GNOME Releases | ColorTint Releases                                                     | Extension Site version |
 |:---------------|:-----------------------------------------------------------------------|:-----------------------|
-| 46             | [latest](https://github.com/MattByName/color-tint/releases/latest)     | tbc                    |
-| 45             | [latest](https://github.com/MattByName/color-tint/releases/latest)     | tbc                    |
+| 48             | [latest](https://github.com/MattByName/color-tint/releases/latest)     | tbc                    |
+| 47             | [latest](https://github.com/MattByName/color-tint/releases/latest)     | tbc                    |
+| 46             | [v3.0.0](https://github.com/MattByName/color-tint/releases/tag/v3.0.0) | tbc                    |
+| 45             | [v3.0.0](https://github.com/MattByName/color-tint/releases/tag/v3.0.0) | tbc                    |
 | 44             | [v2.3.1](https://github.com/MattByName/color-tint/releases/tag/v2.3.1) | 19                     |
 | 43             | [v2.3.1](https://github.com/MattByName/color-tint/releases/tag/v2.3.1) | 19                     |
 | 42             | [v2.3.1](https://github.com/MattByName/color-tint/releases/tag/v2.3.1) | 19                     |

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,5 +1,5 @@
 import St from "gi://St";
-import Clutter from "gi://Clutter";
+import Cogl from "gi://Cogl";
 import Gio from "gi://Gio";
 import GObject from "gi://GObject";
 import * as Main from "resource:///org/gnome/shell/ui/main.js";
@@ -63,7 +63,7 @@ export default class ColorTinter extends Extension {
 
   // Update color of Overlay
   setOverlayColor() {
-    var color = new Clutter.Color({
+    var color = new Cogl.Color({
       red: overlay_color["red"],
       green: overlay_color["green"],
       blue: overlay_color["blue"],

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -9,5 +9,5 @@
     "github": "mattbyname",
     "liberapay": "mattbyname"
   },
-  "shell-version": ["47","48"]
+  "shell-version": ["47","48","49"]
 }

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -9,5 +9,5 @@
     "github": "mattbyname",
     "liberapay": "mattbyname"
   },
-  "shell-version": ["45","46"]
+  "shell-version": ["47","48"]
 }


### PR DESCRIPTION
This PR implements the fixes describe in #32 for GNOME 47 and 48 support. [Per the GJS release notes](https://gjs.guide/extensions/upgrading/gnome-shell-47.html#clutter-color), `Clutter.Color()` was removed and its recommended to switch to `Cogl.Color()`.

Prior to merging this PR, I'd recommend cutting a release of current `main` tagged as `v3.0.0` for gnome 45/46 support so that an earlier tag is accessible for those versions. The PR includes updating the readme reference to that version.

Closes #32