### PR TITLE
remember last tint state

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -9,6 +9,7 @@ import * as PanelMenu from "resource:///org/gnome/shell/ui/panelMenu.js";
 import * as Slider from "resource:///org/gnome/shell/ui/slider.js";
 import { Extension } from "resource:///org/gnome/shell/extensions/extension.js";
 import * as Config from "resource:///org/gnome/shell/misc/config.js";
+import { migrateSettings } from "./migration.js";
 
 const SHELL_VERSION = parseInt(Config.PACKAGE_VERSION.split(".")[0]);
 let overlay_active = false;
@@ -31,6 +32,7 @@ export default class ColorTinter extends Extension {
   enable() {
     tinter = this;
     settings = this.getSettings();
+    migrateSettings(settings);
     metadata = this.metadata;
     this.start_up();
     menu = new MenuButton();
@@ -89,12 +91,14 @@ export default class ColorTinter extends Extension {
   hide() {
     overlay_active = false;
     Main.uiGroup.remove_child(overlay);
+    settings.set_boolean("last-state", false);
   }
 
   // Show Overlay
   show() {
     Main.uiGroup.add_child(overlay);
     overlay_active = true;
+    settings.set_boolean("last-state", true);
   }
 
   // Load Color
@@ -118,11 +122,13 @@ export default class ColorTinter extends Extension {
   }
 
   start_up() {
-    overlay_active = settings.get_boolean("autostart");
+    const behavior = settings.get_enum("startup-behavior"); // 0 off, 1 on, 2 restore
+    overlay_active =
+      behavior === 2 ? settings.get_boolean("last-state") : behavior === 1;
     this.loadColor();
     this.createOverlay();
 
-    if (settings.get_boolean("autostart")) {
+    if (overlay_active) {
       tinter.show();
     }
   }

--- a/src/migration.js
+++ b/src/migration.js
@@ -1,0 +1,7 @@
+export function migrateSettings(settings) {
+  const old = settings.get_user_value("autostart");
+  if (old !== null) {
+    settings.set_enum("startup-behavior", old.get_boolean() ? 1 : 0);
+    settings.reset("autostart");
+  }
+}

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -6,34 +6,27 @@ import {
   ExtensionPreferences,
   gettext as _,
 } from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
+import { migrateSettings } from "./migration.js";
 
 export default class ColorTintPreferences extends ExtensionPreferences {
   fillPreferencesWindow(window) {
     window._settings = this.getSettings();
+    migrateSettings(window._settings);
     // Create a preferences page and group
     const page = new Adw.PreferencesPage();
     const group = new Adw.PreferencesGroup();
     page.add(group);
 
-    // Create a new preferences row
-    const row = new Adw.ActionRow({ title: "Overlay active on start" });
-    group.add(row);
-
-    // Create the switch and bind its value to the `autostart` key
-    const toggle = new Gtk.Switch({
-      active: window._settings.get_boolean("autostart"),
-      valign: Gtk.Align.CENTER,
+    // Combo bound to the `startup-behavior` enum; indices match the enum values
+    const row = new Adw.ComboRow({
+      title: "Overlay on start",
+      model: Gtk.StringList.new(["Off", "On", "Restore last state"]),
     });
-    window._settings.bind(
-      "autostart",
-      toggle,
-      "active",
-      Gio.SettingsBindFlags.DEFAULT
+    row.selected = window._settings.get_enum("startup-behavior");
+    row.connect("notify::selected", () =>
+      window._settings.set_enum("startup-behavior", row.selected)
     );
-
-    // Add the switch to the row
-    row.add_suffix(toggle);
-    row.activatable_widget = toggle;
+    group.add(row);
 
     // Create a new preferences row
     const row_alpha_cap = new Adw.ActionRow({ title: "Cap maximum alpha" });

--- a/src/schemas/org.gnome.shell.extensions.colortint.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.colortint.gschema.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
+  <enum id="org.gnome.shell.extensions.colortint.StartupBehavior">
+    <value value="0" nick="off"/>
+    <value value="1" nick="on"/>
+    <value value="2" nick="restore"/>
+  </enum>
   <schema id="org.gnome.shell.extensions.colortint" path="/org/gnome/shell/extensions/colortint/">
     <!-- See also: https://docs.gtk.org/glib/gvariant-format-strings.html -->
     <key name="monochrome-icon" type="b">
@@ -9,8 +14,18 @@
     </key>
     <key name="autostart" type="b">
       <default>false</default>
-      <summary>Show overlay on start</summary>
-      <description>Whether the overlay should be visible when the extension starts</description>
+      <summary>Show overlay on start (deprecated)</summary>
+      <description>Deprecated: value is migrated to startup-behavior and reset on first run</description>
+    </key>
+    <key name="startup-behavior" enum="org.gnome.shell.extensions.colortint.StartupBehavior">
+      <default>'off'</default>
+      <summary>Overlay on start</summary>
+      <description>Whether the overlay is off, on, or restored to its last state when the extension starts</description>
+    </key>
+    <key name="last-state" type="b">
+      <default>false</default>
+      <summary>Last overlay state</summary>
+      <description>Internal: whether the overlay was on when last toggled</description>
     </key>
     <key name="cap-alpha" type="b">
       <default>true</default>


### PR DESCRIPTION
Useful when tint isn't default all the time. If option gets enabled, then system locked, the option is otherwise reset to default state.
